### PR TITLE
Issues/61

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,9 +1,14 @@
 class TagsController < ApplicationController
   before_action :reject_anonymous
+  before_action :set_perspective
   before_action :set_tag, :except => [ :index, :create, :new ]
 
   def index
-    @tags = Tag.all
+    if @perspective.present?
+      @tags = @perspective.tags
+    else
+      @tags = Tag.all
+    end
   end
 
   def new
@@ -11,20 +16,40 @@ class TagsController < ApplicationController
   end
 
   def create
-    @tag = Tag.new(tag_params)
-    if @tag.save
-      flash[:success] = 'Tag created.'
-      redirect_to @tag
-    else
-      flash.now[:danger] = 'Something went wrong'
-      render :new
+    @tag = Tag.find_by_name(params[:name])
+    @tag = Tag.new(tag_params) unless @tag.present?
+    if @tag.new_record?
+      if @tag.save
+        flash[:success] = 'Tag created.'
+      else
+        flash.now[:danger] = 'Failed to create tag'
+        render :new
+      end
     end
+    if @perspective.present?
+      if @perspective.tags << @tag
+        flash[:success] = "#{@tag.name} assigned to #{@perspective.name}"
+      else
+        flash.now[:danger] = "Failed to assign #{@tag.name} to #{@perspective.name}"
+      end
+      redirect_to @perspective
+    end
+    redirect_to @tag
   end
 
   def show
   end
 
   def destroy
+    if @perspective.present?
+      if @perspective.tags.delete(@tag)
+        flash[:success] = "Unassigned #{@tag.name} from #{@perspective.name}"
+        redirect_to @perspective
+      else
+        flash.now[:danger] = 'Something went wrong'
+        redirect_to @perspective
+      end
+    else
       if @tag.destroy
         flash[:success] = 'Tag removed.'
         redirect_to tags_path
@@ -32,6 +57,7 @@ class TagsController < ApplicationController
         flash.now[:danger] = 'Something went wrong'
         redirect_to @tag
       end
+    end
   end
 
   private
@@ -40,6 +66,12 @@ class TagsController < ApplicationController
     end
 
     def tag_params
-      params.require(:tag).permit([ :name ])
+      params.require(:tag).permit([:name])
+    end
+
+    def set_perspective
+      if params[:medium_id].present?
+        @perspective = Medium.find_by_slug(params[:medium_id])
+      end
     end
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -8,8 +8,12 @@ class Medium < ApplicationRecord
   friendly_id :name, :use => [ :slugged, :finders ]
 
   belongs_to :owner, :class_name => 'User'
+
   has_many :stage_media, :dependent => :destroy
-  has_many :media, :through => :stage_media
+  has_many :stages, :through => :stage_media
+
+  has_many :medium_tags, :dependent => :destroy
+  has_many :tags, :through => :medium_tags
 
   scope :images_only, -> { where(:media_type => 'Image') }
   scope :audio_only, -> { where(:media_type => 'Audio') }

--- a/app/models/medium_tag.rb
+++ b/app/models/medium_tag.rb
@@ -1,0 +1,4 @@
+class MediumTag < ApplicationRecord
+  belongs_to :medium
+  belongs_to :tag
+end

--- a/app/models/medium_tag.rb
+++ b/app/models/medium_tag.rb
@@ -1,4 +1,6 @@
 class MediumTag < ApplicationRecord
   belongs_to :medium
   belongs_to :tag
+
+  validates_uniqueness_of [ :medium, :tag ]
 end

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with :model => @tag do |f| %>
+<%= form_with :model => [@perspective, @tag] do |f| %>
 
 <div class="form-group">
   <%= f.text_field :name, :class => 'form-control', :placeholder => 'Name' %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -3,7 +3,7 @@
     Tags
     <small class="pull-right">
       <span class="btn-group">
-        <%= link_to 'Create', new_tag_path, :class => "btn btn-primary" %>
+        <%= link_to 'Create', @create_path, :class => "btn btn-primary" %>
       </span>
     </small>
   </h1>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -18,7 +18,7 @@
       </td>
       <td>
         <span class="btn-group pull-right">
-          <%= link_to 'Delete', t, :method => :delete, :data => { confirm: "Are you sure?" }, :class => "btn btn-danger" %>
+          <%= link_to @perspective.present? ? 'Unassign' : 'Delete', [@perspective, t], :method => :delete, :data => { confirm: "Are you sure?" }, :class => "btn btn-danger" %>
         </span>
       </td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   resources :stages do
     post '/clone', :to => "stages#clone", :as => 'clone'
   end
-  resources :media
+  resources :media do
+    resources :tags, :param => :name, :except => [ :edit, :update ]
+  end
   resources :stage_media, :only => [ :create, :destroy ]
   resources :roles
   resources :users

--- a/db/migrate/20170503191720_create_medium_tags.rb
+++ b/db/migrate/20170503191720_create_medium_tags.rb
@@ -1,0 +1,10 @@
+class CreateMediumTags < ActiveRecord::Migration[5.1]
+  def change
+    create_table :medium_tags do |t|
+      t.belongs_to :medium, foreign_key: true
+      t.belongs_to :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170503191720_create_medium_tags.rb
+++ b/db/migrate/20170503191720_create_medium_tags.rb
@@ -6,5 +6,6 @@ class CreateMediumTags < ActiveRecord::Migration[5.1]
 
       t.timestamps
     end
+    add_index :medium_tags, [ :medium_id, :tag_id ], :unique => true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20170503191720) do
     t.integer "tag_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["medium_id", "tag_id"], name: "index_medium_tags_on_medium_id_and_tag_id", unique: true
     t.index ["medium_id"], name: "index_medium_tags_on_medium_id"
     t.index ["tag_id"], name: "index_medium_tags_on_tag_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170503151405) do
+ActiveRecord::Schema.define(version: 20170503191720) do
 
   create_table "avatar_stages", force: :cascade do |t|
     t.integer "stage_id"
@@ -44,6 +44,15 @@ ActiveRecord::Schema.define(version: 20170503151405) do
     t.datetime "updated_at", null: false
     t.index ["deleted_at"], name: "index_media_on_deleted_at"
     t.index ["slug", "deleted_at"], name: "index_media_on_slug_and_deleted_at", unique: true
+  end
+
+  create_table "medium_tags", force: :cascade do |t|
+    t.integer "medium_id"
+    t.integer "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["medium_id"], name: "index_medium_tags_on_medium_id"
+    t.index ["tag_id"], name: "index_medium_tags_on_tag_id"
   end
 
   create_table "messages", force: :cascade do |t|

--- a/test/fixtures/medium_tags.yml
+++ b/test/fixtures/medium_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  medium: one
+  tag: one
+
+two:
+  medium: two
+  tag: two

--- a/test/models/medium_tag_test.rb
+++ b/test/models/medium_tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MediumTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Allows tags to be assigned to media via an intermediary model and also adjusts the Tag create and destroy methods based on context.

For example, if the user has opted to create a tag whilst considering the current medium tags, they probably want to add a new tag and assign it to the medium.

We don't want duplicate tags everywhere so logic is in place to reuse an existing tag if the user has entered a tag that already exist.  

Whether the action is adding a tag and assigning it, or simply reusing an existing tag - the user will never know.

Same goes for removal.

The context aware assignment has been made generic so that it can easily be extended when assigning tags to other models in future.