### PR TITLE
Remove duplicate avatar assignment

### DIFF
--- a/app/views/stages/_assign_avatars.html.erb
+++ b/app/views/stages/_assign_avatars.html.erb
@@ -8,7 +8,7 @@
         <h4 class="modal-title">Assign Avatars</h4>
       </div>
       <div class="modal-body">
-        <%= f.select :avatar_id, Avatar.all.map { |a| [ a.name, a.id ] }, {}, :class => "form-control" %>
+        <%= f.select :avatar_id, Avatar.all.map { |a| [ a.name, a.id ] unless @stage.avatars.indlude? a}, {}, :class => "form-control" %>
       </div>
       <div class="modal-footer">
         <button type="submit" name="confirm" class="btn btn-success">


### PR DESCRIPTION
Fixed the issue where User was given the option to assign an avatar to a stage when it was already been assigned. Added a condition to selecting avatars, to not select stage avatars already added.