### PR TITLE
Issue #157

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,11 +65,11 @@ a:hover{
 }
 
 .panel-title {
-  color: #fff !important;
+  color: #000000 !important;
 }
 
 .panel-title > a:hover {
-  color: #fff;
+  color: $upstageGreen;
 }
 
 .navbar-toggle {

--- a/app/views/theatre/performance.html.erb
+++ b/app/views/theatre/performance.html.erb
@@ -80,7 +80,7 @@
             <div class="panel-footer">
               <% @stage.sounds.each do |au| %>
                 <button class="btn btn-default audio-selection" title="<%= au.name %>" data-name="<%= au.name %>" data-audio-id="<%= au.id %>">
-                  <%= image_tag au.source.url(:thumb), :alt => au.name %>
+                  <%=au.name%>
                 </button>
               <% end %>
               </br>

--- a/app/views/theatre/performance.html.erb
+++ b/app/views/theatre/performance.html.erb
@@ -73,11 +73,17 @@
         <div id="audio" class="tab-pane fade">
           <div class="panel-heading">
             <h4 class="panel-title">
-              <a data-toggle="collapse" href="#collapse1">Audio</a>
+              <a class = "audio-display" data-toggle="collapse" href="#collapse1">Audio</a>
             </h4>
           </div>
           <div id="collapse1" class="panel-collapse collapse">
             <div class="panel-footer">
+              <% @stage.sounds.each do |au| %>
+                <button class="btn btn-default audio-selection" title="<%= au.name %>" data-name="<%= au.name %>" data-audio-id="<%= au.id %>">
+                  <%= image_tag au.source.url(:thumb), :alt => au.name %>
+                </button>
+              <% end %>
+              </br>
               <span class="glyphicon glyphicon-headphones"></span>
               Play All Sounds:
               <button class="audio-button all" data-audio-name="all" data-audio-mode ="play">


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/22229579/27616655-65a94c00-5c05-11e7-8fec-50511bce627c.PNG)

Listed audio buttons are now shown but don't play, fixed with no image_tag option.