### PR TITLE
Issue#206

### DIFF
--- a/app/assets/javascripts/channels/avatars.coffee
+++ b/app/assets/javascripts/channels/avatars.coffee
@@ -22,6 +22,9 @@ drop = (data) ->
     dropButton.dataset.avatarId = undefined
     window.holding = undefined
 
+    mirrorDiv = document.querySelector '#mirrorPane'
+    mirrorDiv.innerHTML = ' '
+
 hold = (data) ->
   btn = document.querySelector ".avatar-selection[data-avatar-id='#{data.avatar_id}']"
   btn.setAttribute 'disabled', 'disabled'
@@ -32,6 +35,15 @@ hold = (data) ->
     dropButton.setAttribute 'title', "#{btn.dataset.name}"
     window.holdWait = undefined
     window.holding = data.avatar_id
+
+    mirrorDiv = document.querySelector '#mirrorPane'
+    mirrorImg = new Image
+    mirrorImg.height = 100
+    mirrorImg.width = 100
+    mirrorImg.addEventListener 'load', (e) ->
+      mirrorDiv.appendChild(mirrorImg)
+      mirrorDiv.removeChild(mirrorDiv.childNodes[0])
+    mirrorImg.src = data['file']
 
 document.addEventListener 'turbolinks:load', (e) ->
 

--- a/app/assets/stylesheets/theatre.scss
+++ b/app/assets/stylesheets/theatre.scss
@@ -50,6 +50,11 @@ div#chat > div#chatInput {
   float: centre;
 }
 
+div.mirror {
+  border: solid 1px $upstageGreen;
+  text-align: center;
+}
+
 #avatarButtons {
   width: 4vw;
   height: 4vw;

--- a/app/channels/avatar_channel.rb
+++ b/app/channels/avatar_channel.rb
@@ -8,8 +8,9 @@ class AvatarChannel < ApplicationCable::Channel
   def hold(data)
     unless current_user.nil? || @avatar_allocation[data['avatar_id']] != nil
       @avatar_allocation[data['avatar_id']] = current_user
-      AvatarChannel.broadcast_to @stage, { username: current_user.nickname, action: 'hold', avatar_id: data['avatar_id'] }
-    end
+      avatar = Avatar.find_by_id!(data['avatar_id'])
+      AvatarChannel.broadcast_to @stage, { username: current_user.nickname, action: 'hold', avatar_id: data['avatar_id'], file: avatar.source.url(:original) }
+     end
   end
 
   def drop(data)

--- a/app/channels/avatar_channel.rb
+++ b/app/channels/avatar_channel.rb
@@ -9,7 +9,7 @@ class AvatarChannel < ApplicationCable::Channel
     unless current_user.nil? || @avatar_allocation[data['avatar_id']] != nil
       @avatar_allocation[data['avatar_id']] = current_user
       avatar = Avatar.find_by_id!(data['avatar_id'])
-      AvatarChannel.broadcast_to @stage, { username: current_user.nickname, action: 'hold', avatar_id: data['avatar_id'], file: avatar.source.url(:original) }
+      AvatarChannel.broadcast_to @stage, { username: current_user.id, action: 'hold', avatar_id: data['avatar_id'], file: avatar.source.url(:original) }
      end
   end
 

--- a/app/views/theatre/performance.html.erb
+++ b/app/views/theatre/performance.html.erb
@@ -58,11 +58,15 @@
         </div>
 
         <div id="avatar" class="tab-pane fade">
-            <% @stage.avatars.each do |a| %>
-              <button class="btn btn-default avatar-selection" title="<%= a.name %>" data-name="<%= a.name %>" data-avatar-id="<%= a.id %>">
-                <%= image_tag a.source.url(:thumb), :alt => a.name %>
-              </button>
-            <% end %>
+            <div class="mirror" id="mirrorPane">
+          </div>
+          <div>
+             <% @stage.avatars.each do |a| %>
+               <button class="btn btn-default avatar-selection" title="<%= a.name %>" data-name="<%= a.name %>" data-avatar-id="<%= a.id %>">
+                 <%= image_tag a.source.url(:thumb), :alt => a.name %>
+               </button>
+             <% end %>
+          </div>
             <div>
               <button class="btn btn-default" id="dropAvatarButton" disabled="disabled">
                 Drop


### PR DESCRIPTION
Adds the mirror function to the avatar tab.

Here is the Mirror when no avatar is selected:
![capture_1](https://user-images.githubusercontent.com/22229579/30253753-9ae0ee7c-96df-11e7-9970-58607ec0e689.PNG)

And here is the Mirror after selecting the avatar:
![capture_2](https://user-images.githubusercontent.com/22229579/30253764-b401ba4e-96df-11e7-9925-a441834ecf3d.PNG)

If you scroll down you can see the other buttons to switch/drop avatar again.
