### PR TITLE
Issue#253 fixed backdrop distortion issue

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -30,7 +30,8 @@
       var startingX = (canvas.width - newWidth) / 2
       var startingY = (canvas.height - newHeight) / 2
 
-      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight,startingX,startingY, newWidth,newHeight);
+      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight, 
+                            startingX, startingY, newWidth, newHeight);
     });
 
     // Draw avatars

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -19,7 +19,21 @@
 
     // Draw backdrop
     App.state.backdrops.forEach(function(backdrop){
-      App.context.drawImage(backdrop.image, 0, 0, canvas.width,canvas.height);
+      var newHight;
+      var newWidth;
+      if(backdrop.image.naturalHeight >= backdrop.image.naturalWidth){
+        var ratio = canvas.height/backdrop.image.naturalHeight;
+        newHight = backdrop.image.naturalHeight * ratio;
+        newWidth = backdrop.image.naturalWidth * ratio;
+      } else {
+        var ratio = canvas.width/backdrop.image.naturalWidth;
+        newHight = backdrop.image.naturalHeight * ratio;
+        newWidth = backdrop.image.naturalWidth * ratio;
+      }
+      var startingX = (canvas.width - newWidth) / 2
+      var startingY = (canvas.height - newHight) / 2
+
+      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight,startingX,startingY, newWidth,newHight);
     });
 
     // Draw avatars

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -19,21 +19,18 @@
 
     // Draw backdrop
     App.state.backdrops.forEach(function(backdrop){
-      var newHight;
-      var newWidth;
+      var ratio;
       if(backdrop.image.naturalHeight >= backdrop.image.naturalWidth){
-        var ratio = canvas.height/backdrop.image.naturalHeight;
-        newHight = backdrop.image.naturalHeight * ratio;
-        newWidth = backdrop.image.naturalWidth * ratio;
+        ratio = canvas.height/backdrop.image.naturalHeight;
       } else {
-        var ratio = canvas.width/backdrop.image.naturalWidth;
-        newHight = backdrop.image.naturalHeight * ratio;
-        newWidth = backdrop.image.naturalWidth * ratio;
+        ratio = canvas.width/backdrop.image.naturalWidth;
       }
+      var newHeight = backdrop.image.naturalHeight * ratio;
+      var newWidth = backdrop.image.naturalWidth * ratio;
       var startingX = (canvas.width - newWidth) / 2
-      var startingY = (canvas.height - newHight) / 2
+      var startingY = (canvas.height - newHeight) / 2
 
-      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight,startingX,startingY, newWidth,newHight);
+      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight,startingX,startingY, newWidth,newHeight);
     });
 
     // Draw avatars


### PR DESCRIPTION
when backdrop image is too big it will be drawn within the canvas and centered
when backdrop image is too small it will be drawn bigger, within the canvas and centered

--Long Image(width)--
![screenshot-2017-10-19 test upstage 3](https://user-images.githubusercontent.com/25602185/31754567-04453944-b4f5-11e7-91b5-b4a53c1809c5.png)

--Small Image--
![screenshot-2017-10-19 test upstage 2](https://user-images.githubusercontent.com/25602185/31754568-04814182-b4f5-11e7-8611-30138384ad42.png)

--Large Image(width and height)--
![screenshot-2017-10-19 test upstage 1](https://user-images.githubusercontent.com/25602185/31754570-04b2bbb8-b4f5-11e7-9e20-c88a00c91717.png)

--Small Square Image--
![screenshot-2017-10-19 test upstage](https://user-images.githubusercontent.com/25602185/31754571-04dfe4a8-b4f5-11e7-972a-11581b988770.png)
