### PR TITLE
Issue#269 Swap Avatar without dropping

### DIFF
--- a/app/assets/javascripts/channels/avatars.coffee
+++ b/app/assets/javascripts/channels/avatars.coffee
@@ -61,10 +61,10 @@ drop = (data) ->
     mirrorDiv.innerHTML = ' '
 
 hold = (data) ->
-  if window.holding != undefined
-    holdbtn = document.querySelector ".avatar-selection[data-avatar-id='#{window.holding}']"
+  if data.holding != null
+    holdbtn = document.querySelector ".avatar-selection[data-avatar-id='#{data.holding}']"
     holdbtn.removeAttribute 'disabled'
-    holdbtn.setAttribute 'title', "#{holdbtn.dataset.name}"
+    holdbtn.setAttribute 'title', "#{holdbtn.getAttribute 'data-avatar-name'}"
   btn = document.querySelector ".avatar-selection[data-avatar-id='#{data.avatar_id}']"
   btn.setAttribute 'disabled', 'disabled'
   btn.setAttribute 'title', "#{btn.getAttribute 'title'} (#{data.username})"
@@ -137,7 +137,7 @@ document.addEventListener 'turbolinks:load', (e) ->
 
     hold: (avatarId) ->
       window.holdWait = avatarId
-      @perform 'hold', avatar_id: avatarId
+      @perform 'hold', avatar_id: avatarId, holding: window.holding
 
     size: (value) ->
       if window.holding != undefined

--- a/app/assets/javascripts/channels/avatars.coffee
+++ b/app/assets/javascripts/channels/avatars.coffee
@@ -68,7 +68,7 @@ hold = (data) ->
   btn = document.querySelector ".avatar-selection[data-avatar-id='#{data.avatar_id}']"
   btn.setAttribute 'disabled', 'disabled'
   btn.setAttribute 'title', "#{btn.getAttribute 'title'} (#{data.username})"
-  console.log(App.state.avatars)
+
   if `data.avatar_id == window.holdWait`
     dropButton = document.querySelector '#dropAvatarButton'
     dropButton.removeAttribute 'disabled'
@@ -113,7 +113,6 @@ document.addEventListener 'turbolinks:load', (e) ->
   document.querySelectorAll('.avatar-selection').forEach (elem) ->
     elem.addEventListener 'mouseup', (e) ->
       App.avatar.hold this.dataset.avatarId
-      console.log("image clicked: " + this.dataset.avatarId)
 
   document.querySelector('#avatarSlider').addEventListener 'change', (e) ->
     App.avatar.size document.querySelector('#avatarSlider').value

--- a/app/assets/javascripts/channels/avatars.coffee
+++ b/app/assets/javascripts/channels/avatars.coffee
@@ -61,9 +61,14 @@ drop = (data) ->
     mirrorDiv.innerHTML = ' '
 
 hold = (data) ->
+  if window.holding != undefined
+    holdbtn = document.querySelector ".avatar-selection[data-avatar-id='#{window.holding}']"
+    holdbtn.removeAttribute 'disabled'
+    holdbtn.setAttribute 'title', "#{holdbtn.dataset.name}"
   btn = document.querySelector ".avatar-selection[data-avatar-id='#{data.avatar_id}']"
   btn.setAttribute 'disabled', 'disabled'
   btn.setAttribute 'title', "#{btn.getAttribute 'title'} (#{data.username})"
+  console.log(App.state.avatars)
   if `data.avatar_id == window.holdWait`
     dropButton = document.querySelector '#dropAvatarButton'
     dropButton.removeAttribute 'disabled'
@@ -108,6 +113,7 @@ document.addEventListener 'turbolinks:load', (e) ->
   document.querySelectorAll('.avatar-selection').forEach (elem) ->
     elem.addEventListener 'mouseup', (e) ->
       App.avatar.hold this.dataset.avatarId
+      console.log("image clicked: " + this.dataset.avatarId)
 
   document.querySelector('#avatarSlider').addEventListener 'change', (e) ->
     App.avatar.size document.querySelector('#avatarSlider').value

--- a/app/channels/avatar_channel.rb
+++ b/app/channels/avatar_channel.rb
@@ -6,7 +6,7 @@ class AvatarChannel < ApplicationCable::Channel
   end
 
   def hold(data)
-    unless current_user.nil? || @avatar_allocation[data['avatar_id']] != nil
+    unless current_user.nil? 
       @avatar_allocation[data['avatar_id']] = current_user
       avatar = Avatar.find_by_id!(data['avatar_id'])
       AvatarChannel.broadcast_to @stage, { username: current_user.id, action: 'hold', avatar_id: data['avatar_id'], file: avatar.source.url(:original) }
@@ -47,9 +47,9 @@ class AvatarChannel < ApplicationCable::Channel
   def size(data)
     unless current_user.nil? || @avatar_allocation[data['avatar_id']] != current_user
       avatar = Avatar.find_by_id!(data['avatar_id'])
-      AvatarChannel.broadcast_to @stage, { 
-        action: 'size', 
-        avatar_id: data['avatar_id'], 
+      AvatarChannel.broadcast_to @stage, {
+        action: 'size',
+        avatar_id: data['avatar_id'],
         value: data['value'],
         file: avatar.source.url(:original)
       }

--- a/app/channels/avatar_channel.rb
+++ b/app/channels/avatar_channel.rb
@@ -6,11 +6,17 @@ class AvatarChannel < ApplicationCable::Channel
   end
 
   def hold(data)
-    unless current_user.nil? 
+    unless current_user.nil? || @avatar_allocation[data['avatar_id']] != nil && @avatar_allocation[data['avatar_id']] != current_user
       @avatar_allocation[data['avatar_id']] = current_user
       avatar = Avatar.find_by_id!(data['avatar_id'])
-      AvatarChannel.broadcast_to @stage, { username: current_user.id, action: 'hold', avatar_id: data['avatar_id'], file: avatar.source.url(:original) }
-     end
+      AvatarChannel.broadcast_to @stage, {
+        username: current_user.id,
+        action: 'hold',
+        avatar_id: data['avatar_id'],
+        holding: data['holding'],
+        file: avatar.source.url(:original)
+      }
+    end
   end
 
   def drop(data)


### PR DESCRIPTION
Swap Avatar without dropping.
![image](https://user-images.githubusercontent.com/26214298/32540011-329e7f7c-c4d0-11e7-8f35-0c41bf6712bb.png)
![image](https://user-images.githubusercontent.com/26214298/32540030-454ec050-c4d0-11e7-8b92-d23e7d36b36d.png)
![image](https://user-images.githubusercontent.com/26214298/32540061-65bf19de-c4d0-11e7-99a8-f41cf0197e14.png)
![image](https://user-images.githubusercontent.com/26214298/32540071-6ff16182-c4d0-11e7-8017-7ddf9eebf91f.png)

Fixed the bug that you can't hold previously placed avatars.
![image](https://user-images.githubusercontent.com/26214298/32540130-944d9ad2-c4d0-11e7-925e-f945b7f389b5.png)
![image](https://user-images.githubusercontent.com/26214298/32540151-a3d8a3b6-c4d0-11e7-9b7c-297a42fce8c5.png)
