### PR TITLE
Issue#285 adding whitespace correctly for backdrops

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -30,7 +30,7 @@
       var startingX = (canvas.width - newWidth) / 2
       var startingY = (canvas.height - newHeight) / 2
 
-      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight, 
+      App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight,
                             startingX, startingY, newWidth, newHeight);
     });
 
@@ -68,8 +68,7 @@
     App.canvas = document.querySelector('#canvas');
     App.context = App.canvas.getContext('2d');
     App.slug = document.querySelector('meta[name="stage-slug"]').getAttribute('value');
-    window.addEventListener('resize', App.resizeCanvas());
-    App.resizeCanvas();
+    window.addEventListener('resize', App.resizeCanvas);
   });
 
 }).call(this);

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -21,14 +21,22 @@
     App.state.backdrops.forEach(function(backdrop){
       var ratio;
       if(backdrop.image.naturalHeight >= backdrop.image.naturalWidth){
-        ratio = canvas.height/backdrop.image.naturalHeight;
+        if(canvas.width * backdrop.image.naturalHeight / backdrop.image.naturalWidth > canvas.height){
+          ratio = canvas.height/backdrop.image.naturalHeight;
+        } else {
+          ratio = canvas.width/backdrop.image.naturalWidth;
+        }
       } else {
-        ratio = canvas.width/backdrop.image.naturalWidth;
+        if(canvas.height * backdrop.image.naturalWidth / backdrop.image.naturalHeight > canvas.width){
+          ratio = canvas.width/backdrop.image.naturalWidth;
+        } else {
+          ratio = canvas.height/backdrop.image.naturalHeight;
+        }
       }
       var newHeight = backdrop.image.naturalHeight * ratio;
       var newWidth = backdrop.image.naturalWidth * ratio;
-      var startingX = (canvas.width - newWidth) / 2
-      var startingY = (canvas.height - newHeight) / 2
+      var startingX = (canvas.width - newWidth) / 2;
+      var startingY = (canvas.height - newHeight) / 2;
 
       App.context.drawImage(backdrop.image, 0, 0, backdrop.image.naturalWidth, backdrop.image.naturalHeight,
                             startingX, startingY, newWidth, newHeight);
@@ -69,6 +77,7 @@
     App.context = App.canvas.getContext('2d');
     App.slug = document.querySelector('meta[name="stage-slug"]').getAttribute('value');
     window.addEventListener('resize', App.resizeCanvas);
+    App.resizeCanvas();
   });
 
 }).call(this);


### PR DESCRIPTION
**1.  Landscape backdrop**

- Long screen
![image](https://user-images.githubusercontent.com/26214298/33067007-bcbfc440-cf11-11e7-829c-52353425984f.png)

- Wide screen
![image](https://user-images.githubusercontent.com/26214298/33067088-f6fbf73c-cf11-11e7-9e21-2f8b1ab9bdcd.png)
- Wide screen and wider than the image's width
![image](https://user-images.githubusercontent.com/26214298/33067105-07753c22-cf12-11e7-88a5-6de5caf89f93.png)

**2. Portrait backdrop**

- Long screen
![image](https://user-images.githubusercontent.com/26214298/33067234-6b3c132a-cf12-11e7-802e-598435a201d4.png)

- Wide screen
![image](https://user-images.githubusercontent.com/26214298/33067195-4c40784e-cf12-11e7-915c-ec42fb4a641f.png)
