### PR TITLE
Added drag and drop function to the canvas

### DIFF
--- a/app/assets/javascripts/channels/theatre.coffee
+++ b/app/assets/javascripts/channels/theatre.coffee
@@ -58,21 +58,23 @@ jQuery(document).on 'turbolinks:load', ->
     canvas.on 'mousedown touchstart', (e) ->
       if(window.holding != undefined)
         avatar = App.state.avatars[window.holding]
-      if(avatar != undefined && e.clientX >= avatar.x && e.clientX <= (avatar.width + avatar.x) && e.clientY >= avatar.y && e.clientY <= (avatar.height + avatar.y))
-        dragging = true
-      else
-        e.preventDefault()
+        if(avatar != undefined)
+          if(e.clientX >= avatar.x && e.clientX <= (avatar.width + avatar.x))
+            if(e.clientY >= avatar.y && e.clientY <= (avatar.height + avatar.y))
+              dragging = true
+
+      e.preventDefault()
+      x = e.offsetX
+      y = e.offsetY
+
+      if e.originalEvent.changedTouches
+        e = e.originalEvent.changedTouches[0]
         x = e.offsetX
         y = e.offsetY
 
-        if e.originalEvent.changedTouches
-          e = e.originalEvent.changedTouches[0]
-          x = e.offsetX
-          y = e.offsetY
-
-        drawing = true
-        prev.x = x
-        prev.y = y
+      drawing = true
+      prev.x = x
+      prev.y = y
 
     canvas.bind 'mouseup mouseleave touchend', ->
       drawing = false
@@ -86,7 +88,9 @@ jQuery(document).on 'turbolinks:load', ->
           context.clearRect(0, 0, innerWidth, innerHeight);
           App.drawFrame()
           context.globalAlpha = 0.4
-          context.drawImage(img, e.clientX-avatar.width/2, e.clientY-avatar.height/2, avatar.width, avatar.height)
+          x = e.clientX - (avatar.width / 2)
+          y = e.clientY - (avatar.height / 2)
+          context.drawImage(img, x, y, avatar.width, avatar.height)
           context.globalAlpha = 1.0
         img.src = avatar.image.src
       else if(drawing && $.now() - timeSinceLastSend > 10)

--- a/app/assets/javascripts/channels/theatre.coffee
+++ b/app/assets/javascripts/channels/theatre.coffee
@@ -15,6 +15,7 @@ jQuery(document).on 'turbolinks:load', ->
     drawing = false
     timeSinceLastSend = $.now()
     size = 1
+    dragging = false
 
     $('.color-option').click  ->
       color = $(this).data("color")
@@ -55,24 +56,40 @@ jQuery(document).on 'turbolinks:load', ->
           document.getElementById("brushSize").innerHTML = size
 
     canvas.on 'mousedown touchstart', (e) ->
-      e.preventDefault()
-      x = e.offsetX
-      y = e.offsetY
-
-      if e.originalEvent.changedTouches
-        e = e.originalEvent.changedTouches[0]
+      if(window.holding != undefined)
+        avatar = App.state.avatars[window.holding]
+      if(avatar != undefined && e.clientX >= avatar.x && e.clientX <= (avatar.width + avatar.x) && e.clientY >= avatar.y && e.clientY <= (avatar.height + avatar.y))
+        dragging = true
+      else
+        e.preventDefault()
         x = e.offsetX
         y = e.offsetY
 
-      drawing = true
-      prev.x = x
-      prev.y = y
+        if e.originalEvent.changedTouches
+          e = e.originalEvent.changedTouches[0]
+          x = e.offsetX
+          y = e.offsetY
+
+        drawing = true
+        prev.x = x
+        prev.y = y
 
     canvas.bind 'mouseup mouseleave touchend', ->
       drawing = false
+      dragging = false
 
     canvas.on 'mousemove touchmove', (e) ->
-      if(drawing && $.now() - timeSinceLastSend > 10)
+      if(dragging)
+        avatar = App.state.avatars[window.holding]
+        img = new Image()
+        img.onload = ->
+          context.clearRect(0, 0, innerWidth, innerHeight);
+          App.drawFrame()
+          context.globalAlpha = 0.4
+          context.drawImage(img, e.clientX-avatar.width/2, e.clientY-avatar.height/2, avatar.width, avatar.height)
+          context.globalAlpha = 1.0
+        img.src = avatar.image.src
+      else if(drawing && $.now() - timeSinceLastSend > 10)
         x = e.offsetX
         y = e.offsetY
         stage_id = $('#stage-id').val()


### PR DESCRIPTION
Player are now able to drag avatar around on stage, when the player is dragging the avatar it will have a shadow effect of on avatar.
When the avatar is released it avatar will move to its new position.

When moving the avatar around drawing function will not work.

![37](https://user-images.githubusercontent.com/25602185/37374232-effadfdc-277e-11e8-87b5-b2631764c8a5.png)
