### PR TITLE
Amend Issue #166

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -23,6 +23,6 @@ class MessagesController < ApplicationController
   end
 
   def user
-    return current_user.nickname
+    return current_user.username
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by_email(params[:uid])
     unless EmailValidator.valid?(params[:uid])
-      user = User.find_by_nickname(params[:uid])
+      user = User.find_by_username(params[:uid])
     end
     if user && user.authenticate(params[:password])
       if user.is_active

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   before_action :reject_anonymous, :except => [ :new, :create ]
+  before_action :force_lowercase_uid
   invisible_captcha :only => [ :create ], :honeypot => :bucket
 
   def new
@@ -36,4 +37,9 @@ class SessionsController < ApplicationController
     flash[:success] = "Successfully logged out"
     redirect_to root_url
   end
+
+  private
+    def force_lowercase_uid
+      params[:uid] = params[:uid].downcase unless params[:uid].nil?
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -102,10 +102,10 @@ class UsersController < ApplicationController
     end
 
     def new_user_params
-      params.require(:user).permit([ :email, :nickname, :password, :password_confirmation ])
+      params.require(:user).permit([ :email, :username, :password, :password_confirmation ])
     end
 
     def update_user_params
-      params.require(:user).permit([ :email, :nickname, :is_active ])
+      params.require(:user).permit([ :email, :username, :is_active ])
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,10 +18,10 @@ class User < ApplicationRecord
   has_many :announcements
 
   validates :email, :email => true, :presence => true, :uniqueness => true
-  validates :nickname, :presence => true, :length => { minimum: 3 }, :uniqueness => true
+  validates :username, :presence => true, :length => { minimum: 3 }, :uniqueness => true
 
 
-  friendly_id :nickname, use: [ :slugged, :finders ]
+  friendly_id :username, use: [ :slugged, :finders ]
 
   def request_password_reset
     generate_token(:password_reset_token)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   before_create { generate_token(:auth_token) }
   before_create { generate_token(:confirmation_token) }
+  before_validation { self.username = self.username.downcase }
 
   after_create :send_email_confirmation
   after_update :send_activation_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   before_create { generate_token(:auth_token) }
   before_create { generate_token(:confirmation_token) }
-  before_validation { self.username = self.username.downcase }
+  before_validation :downcase_credentials
 
   after_create :send_email_confirmation
   after_update :send_activation_email
@@ -47,5 +47,10 @@ class User < ApplicationRecord
       if self.is_active_was == false && self.is_active
         UserMailer.account_activated(self).deliver_now
       end
+    end
+
+    def downcase_credentials
+      self.username = self.username.downcase
+      self.email = self.email.downcase
     end
 end

--- a/app/views/announcements/_announcement.html.erb
+++ b/app/views/announcements/_announcement.html.erb
@@ -2,7 +2,7 @@
   <h4>
     <%= link_to announcement.title, announcement %>
     <br>
-    <small><%= "#{localize(announcement.updated_at, :format => :long)} by #{announcement.author.nickname}" %></small>
+    <small><%= "#{localize(announcement.updated_at, :format => :long)} by #{announcement.author.username}" %></small>
   </h4>
   <%= announcement.body[0..50].html_safe %>
 </div>

--- a/app/views/announcements/_form.html.erb
+++ b/app/views/announcements/_form.html.erb
@@ -23,7 +23,7 @@
 </div>
 
 <div class="form_group">
-  <span class="text-muted">by <%= f.object.author.nickname %></span>
+  <span class="text-muted">by <%= f.object.author.username %></span>
 </div>
 
 <div class="form-group">

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -21,7 +21,7 @@
       <%= @announcement.subtitle unless @announcement.subtitle.blank? %>
     </small>
   </h1>
-  <p class="text-muted">by <%= @announcement.author.nickname %></p>
+  <p class="text-muted">by <%= @announcement.author.username %></p>
   <p class="text-muted">Last Modified: <%= localize(@announcement.updated_at, :format => :long) %></p>
 </div>
 

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -11,7 +11,7 @@
     <% unless message.nickname == "" %>
       <%= message.nickname %>
     <% else %>
-      <%= message.sender.nil? ? '' : message.sender.nickname %>
+      <%= message.sender.nil? ? '' : message.sender.username %>
     <%end%>
   </span>
   <div class="content <%= cls %>">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="panel-body">
       <div class="form-group">
-        <%= text_field_tag 'uid', nil, :class => 'form-control', :placeholder => 'Email or Nickname' %>
+        <%= text_field_tag 'uid', nil, :class => 'form-control', :placeholder => 'Email or Username' %>
       </div>
       <div class="form-group">
         <%= password_field_tag 'password', nil, :class => 'form-control', :placeholder => 'Password' %>

--- a/app/views/stages/_form.html.erb
+++ b/app/views/stages/_form.html.erb
@@ -12,7 +12,7 @@
 </div>
 
 <div class="form-group">
-  <small>Owned by: <%= @stage.owner.nickname %></small>
+  <small>Owned by: <%= @stage.owner.username %></small>
 </div>
 
 <div class="form-group">

--- a/app/views/subscriptions_mailer/make_announcement.html.erb
+++ b/app/views/subscriptions_mailer/make_announcement.html.erb
@@ -6,7 +6,7 @@
       <%= @announcement.subtitle unless @announcement.subtitle.blank? %>
     </small>
   </h1>
-  <p>by <%= @announcement.author.nickname %></p>
+  <p>by <%= @announcement.author.username %></p>
   <p>Last Modified: <%= localize(@announcement.updated_at, :format => :long) %></p>
 </div>
 

--- a/app/views/theatre/_announcement.html.erb
+++ b/app/views/theatre/_announcement.html.erb
@@ -1,5 +1,5 @@
 <div class="panel">
-  <%= link_to announcement.title, announcement %> by <%= announcement.author.nickname %>
+  <%= link_to announcement.title, announcement %> by <%= announcement.author.username %>
   <br>
   <p class="text-muted">
     <%= localize(announcement.updated_at, :format => :short) %>

--- a/app/views/theatre/performance.html.erb
+++ b/app/views/theatre/performance.html.erb
@@ -151,7 +151,7 @@
           </div>
           <input type="hidden" id="stage-id" name ="stage-id" value ="<%= @stage.id %>">
           <input type="hidden" id="user-id" name ="user-id" value ="<%= current_user ? current_user.id : 0 %>">
-          <input type="hidden" id="user-name" name ="user-name" value ="<%= current_user ? current_user.nickname : 'Guest' %>">
+          <input type="hidden" id="user-name" name ="user-name" value ="<%= current_user ? current_user.username : 'Guest' %>">
         </div>
       </div>
     </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -40,10 +40,10 @@
 <% end %>
 
   <div class="form-group">
-    <%= f.text_field :nickname, :class => "form-control", :placeholder => 'Nickname' %>
-    <% unless @user.errors[:nickname].empty? %>
+    <%= f.text_field :username, :class => "form-control", :placeholder => 'Nickname' %>
+    <% unless @user.errors[:username].empty? %>
       <p class="text-danger">
-        <% @user.errors.full_messages_for(:nickname).each do |e| %>
+        <% @user.errors.full_messages_for(:username).each do |e| %>
           <%= e %><br>
         <% end %>
       </p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
-<% @title = "Edit User \'#{@user.nickname}\'" %>
+<% @title = "Edit User \'#{@user.username}\'" %>
 
 <div class="page-header">
-  <h1>Edit User<br><small><%= @user.nickname %></small></h1>
+  <h1>Edit User<br><small><%= @user.username %></small></h1>
 </div>
 
 <%= render 'form' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,9 +17,9 @@
     <tr>
       <td>
         <% if u.is_active? %>
-          <%= link_to u.nickname, u %>
+          <%= link_to u.username, u %>
         <% else %>
-          <%= u.nickname %>
+          <%= u.username %>
           <br>
           <span class="text-danger small">Inactive</span>
         <% end %>
@@ -31,7 +31,7 @@
       <td>
         <span class="btn-group pull-right">
           <%= link_to 'Edit', edit_user_path(u), :class => "btn btn-default" %>
-          <%= link_to 'Delete', u, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{u.nickname}\"?" }, :class => "btn btn-danger" %>
+          <%= link_to 'Delete', u, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{u.username}\"?" }, :class => "btn btn-danger" %>
         </span>
       </td>
     </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,12 @@
-<% @title = @user.nickname %>
+<% @title = @user.username %>
 
 <div class="page-header">
   <h1>
-    <%= @user.nickname %>
+    <%= @user.username %>
     <small class="pull-right">
       <span class="btn-group">
         <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-default" %>
-        <%= link_to 'Delete', @user, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{@user.nickname}\"?" }, :class => "btn btn-danger" %>
+        <%= link_to 'Delete', @user, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{@user.username}\"?" }, :class => "btn btn-danger" %>
       </span>
     </small>
   </h1>

--- a/db/migrate/20180417231338_change_user_nickname_to_username.rb
+++ b/db/migrate/20180417231338_change_user_nickname_to_username.rb
@@ -1,0 +1,5 @@
+class ChangeUserNicknameToUsername < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :users, :nickname, :username
+  end
+end

--- a/db/migrate/20180417234942_force_lowercase_usernames.rb
+++ b/db/migrate/20180417234942_force_lowercase_usernames.rb
@@ -1,0 +1,9 @@
+class ForceLowercaseUsernames < ActiveRecord::Migration[5.1]
+  def change
+    User.all.each do |u|
+      u.username = u.username.downcase
+      u.email = u.email.downcase
+      u.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180417231338) do
+ActiveRecord::Schema.define(version: 20180417234942) do
 
   create_table "announcements", force: :cascade do |t|
     t.string "title", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180403235530) do
+ActiveRecord::Schema.define(version: 20180417231338) do
 
   create_table "announcements", force: :cascade do |t|
     t.string "title", null: false
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 20180403235530) do
     t.string "email", null: false
     t.string "password_digest", null: false
     t.string "auth_token", null: false
-    t.string "nickname", null: false
+    t.string "username", null: false
     t.boolean "is_active", default: false, null: false
     t.string "slug", null: false
     t.datetime "deleted_at"
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(version: 20180403235530) do
     t.string "confirmation_token", default: "CONFIRMED", null: false
     t.string "password_reset_token"
     t.datetime "password_reset_sent_at"
-    t.index ["deleted_at", "nickname"], name: "index_users_on_deleted_at_and_nickname", unique: true
+    t.index ["deleted_at", "username"], name: "index_users_on_deleted_at_and_username", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email"
     t.index ["is_active"], name: "index_users_on_is_active"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+User.create({ username: 'admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })

--- a/spec/controllers/backdrops_controller_spec.rb
+++ b/spec/controllers/backdrops_controller_spec.rb
@@ -16,7 +16,7 @@ describe BackdropsController do
 		end
 
 		it "render 'index' template" do
-			user = User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+			user = User.create({ username: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
 			cookies[:auth_token] = user.auth_token
 			get :index
 			expect(response).to render_template('index')
@@ -41,8 +41,8 @@ describe BackdropsController do
 
 	describe "POST #create" do
 		before do
-			user = User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
-			cookies[:auth_token] = user.auth_token			
+			user = User.create({ username: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+			cookies[:auth_token] = user.auth_token
 		end
 
 		context "when there is a valid backdrop" do
@@ -76,7 +76,7 @@ describe BackdropsController do
 		subject { post :create, :params => { :backdrop => { name: "Pass Type", source_name: "bg1", source_content_type: "image/png" } } }
 
 	 	it "redirect to edit backdrop path" do
-	 		user = User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+	 		user = User.create({ username: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
 			cookies[:auth_token] = user.auth_token
 			expect(subject).to redirect_to(edit_backdrop_path(Backdrop.last))
 	 	end
@@ -84,8 +84,8 @@ describe BackdropsController do
 
 	describe "#PATCH update" do
 		before do
-			user = User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
-			cookies[:auth_token] = user.auth_token			
+			user = User.create({ username: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+			cookies[:auth_token] = user.auth_token
 		end
 
 		context "when a stage is present" do
@@ -98,7 +98,7 @@ describe BackdropsController do
 				@backdrop.reload
 			end
 
-			it "add backdrop to the stage" do				
+			it "add backdrop to the stage" do
 				expect(@stage.backdrops).to include(@backdrop)
 			end
 
@@ -152,8 +152,8 @@ describe BackdropsController do
 
 	describe "DELETE destroy" do
 		before do
-			user = User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
-			cookies[:auth_token] = user.auth_token			
+			user = User.create({ username: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+			cookies[:auth_token] = user.auth_token
 		end
 
 		context "when a stage is present" do
@@ -179,7 +179,7 @@ describe BackdropsController do
 			end
 		end
 
-		context "when a stage not present" do		
+		context "when a stage not present" do
 			context "when @backdrop.destroy is true" do
 				before do
 					@backdrop = Backdrop.create(name: "bg1")
@@ -199,15 +199,15 @@ describe BackdropsController do
 				end
 			end
 
-			context "when @backdrop.destroy is false" do		
+			context "when @backdrop.destroy is false" do
 				it "flash danger message" do
 					backdrop = double
 					allow(Backdrop).to receive(:find_by_slug!).and_return(backdrop)
 					allow(backdrop).to receive(:slug).and_return("abc")
 					allow(backdrop).to receive(:destroy).and_return(false)
 
-					delete :destroy, :params => { slug: backdrop.slug, backdrop: backdrop }	
-					
+					delete :destroy, :params => { slug: backdrop.slug, backdrop: backdrop }
+
 					expect(flash[:danger]).to be_present
 				end
 
@@ -218,7 +218,7 @@ describe BackdropsController do
 					allow(backdrop).to receive(:destroy).and_return(false)
 
 					delete :destroy, :params => { slug: backdrop.slug, backdrop: backdrop }
-					
+
 					expect(response).to redirect_to(edit_backdrop_path(backdrop))
 				end
 			end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TagsController, type: :controller do
 
   describe "POST #create" do
     before do
-      user = User.create({ nickname: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
+      user = User.create({ username: 'Admin', email: 'admin@local.instance', password: 'admin', password_confirmation: 'admin', is_active: true, email_confirmed: Time.zone.now })
       cookies[:auth_token] = user.auth_token
     end
 


### PR DESCRIPTION
- Changes ```User.nickname``` to ```User.username```

I also noticed that we'd overlooked the fact that find_by_* is case sensitive.  So I've put in migrations to ensure all existing usernames and emails are lowercase and then enforced it at the model layer.  Also, ```session#create``` now automatically lowers the case of ```parms[:uid]```