### PR TITLE
Issue#230

### DIFF
--- a/app/views/stages/_form.html.erb
+++ b/app/views/stages/_form.html.erb
@@ -17,6 +17,9 @@
 
 <div class="form-group">
   <%= f.submit ( @stage.new_record? ? 'Create' : 'Edit' ), :class => 'btn btn-primary' %>
+  <% unless @stage.new_record? %>
+    <%= link_to 'Delete', @stage, :method => :delete, :data => { confirm: "This stage will be deleted immediately and will no longer be available.", title: "Are you sure you want to delete the stage \"#{@stage.name}\"?" }, :class => "btn btn-danger" %>
+  <% end %>
 </div>
 
 <% end %>

--- a/app/views/stages/index.html.erb
+++ b/app/views/stages/index.html.erb
@@ -19,7 +19,7 @@
         <%= link_to s.name, s %>
       </td>
       <td>
-        <span class="btn-group pull-right">
+        <span class="pull-right">
           <%= link_to 'Enter', performance_path(s), :class => "btn btn-default" %>
           <%= link_to 'Edit', edit_stage_path(s), :class => "btn btn-default" %>
         </span>

--- a/app/views/stages/index.html.erb
+++ b/app/views/stages/index.html.erb
@@ -20,8 +20,8 @@
       </td>
       <td>
         <span class="btn-group pull-right">
+          <%= link_to 'Enter', performance_path(s), :class => "btn btn-default" %>
           <%= link_to 'Edit', edit_stage_path(s), :class => "btn btn-default" %>
-          <%= link_to 'Delete', s, :method => :delete, :data => { confirm: "This stage will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the stage \"#{s.name}\"?" }, :class => "btn btn-danger" %>
         </span>
       </td>
     </tr>

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -4,13 +4,11 @@
   <h1>
     <%= @stage.name %>
     <small class="pull-right">
-      <span class="btn-group">
-        <%= link_to 'Edit', edit_stage_path(@stage), :class => "btn btn-default" %>
-          <a class="btn btn-default" href="#" data-toggle="modal" data-target="#cloneStageModal">
-            Clone
-          </a>
-        <%= link_to 'Delete', @stage, :method => :delete, :data => { confirm: "This stage will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the stage \"#{@stage.name}\"?" }, :class => "btn btn-danger" %>
-      </span>
+      <%= link_to 'Edit', edit_stage_path(@stage), :class => "btn btn-default" %>
+        <a class="btn btn-default" href="#" data-toggle="modal" data-target="#cloneStageModal">
+          Clone
+        </a>
+      <%= link_to 'Delete', @stage, :method => :delete, :data => { confirm: "This stage will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the stage \"#{@stage.name}\"?" }, :class => "btn btn-danger" %>
     </small>
     <br>
     <small>Stage</small>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,7 +29,7 @@
         <% end %>
       </td>
       <td>
-        <span class="btn-group pull-right">
+        <span class="pull-right">
           <%= link_to 'Edit', edit_user_path(u), :class => "btn btn-default" %>
           <%= link_to 'Delete', u, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{u.username}\"?" }, :class => "btn btn-danger" %>
         </span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,10 +4,8 @@
   <h1>
     <%= @user.username %>
     <small class="pull-right">
-      <span class="btn-group">
-        <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-default" %>
-        <%= link_to 'Delete', @user, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{@user.username}\"?" }, :class => "btn btn-danger" %>
-      </span>
+      <%= link_to 'Edit', edit_user_path(@user), :class => "btn btn-default" %>
+      <%= link_to 'Delete', @user, :method => :delete, :data => { confirm: "This user will be deleted immediately and no longer be available.", title: "Are you sure you want to delete the user \"#{@user.username}\"?" }, :class => "btn btn-danger" %>
     </small>
   </h1>
 </div>


### PR DESCRIPTION
For each stage in the Stages page, 'Enter' and 'Edit' buttons are now only shown. 'Delete' button for deleting a specific stage is now only available when you are in the Edit page for that specific stage. Tested on Chrome and Firefox locally in my Oracle VM. Needs further approval.

Edit - 12:00PM Wednesday 9th May (09/05/18)
I have tested this on Microsoft Edge on Windows through port forwarding via Oracle VM. This works as intended.